### PR TITLE
Added 60dB integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,18 @@
+# TTS provider selection: elevenlabs (default) | 60db
+TTS_PROVIDER=elevenlabs
+
+# ElevenLabs (used when TTS_PROVIDER=elevenlabs)
 ELEVEN_VOICE_ID=ErXwobaYiN019PkySvjV
 ELEVEN_API_KEY=xxxxxxxxxx
+
+# 60db (used when TTS_PROVIDER=60db)
+SIXTYDB_API_KEY=xxxxxxxxxx
+SIXTYDB_VOICE_ID=
+SIXTYDB_OUTPUT_FORMAT=mp3
+# Optional voice tuning (left unset -> 60db defaults). speed 0.5-2.0, stability/similarity 0-100
+# SIXTYDB_SPEED=1
+# SIXTYDB_STABILITY=50
+# SIXTYDB_SIMILARITY=75
+
 OPENAI_API_KEY=xxxxxxxxxx
 TIKTOK_USERNAME=whyweru

--- a/README.md
+++ b/README.md
@@ -22,16 +22,24 @@
 <p align="center">Love the project? Please consider <a href="https://ko-fi.com/whyweru">donating</a> to help it improve!</p>
 
 ## Getting Started
-To run this code, you require an API key from ElevenLabs and OpenAI.
-
-### ElevenLabs API Key
-- Sign up [here](https://beta.elevenlabs.io/sign-up) for a free account.
+To run this code you require an API key from OpenAI and **one** text-to-speech (TTS) provider — either **ElevenLabs** or **60db**. The TTS provider is selectable at runtime, so you only need credentials for the one you intend to use.
 
 ### OpenAI API Key
 - Sign up [here](https://platform.openai.com/signup) for a free account.
 
+### TTS Provider
+The bot speaks its responses through a pluggable TTS layer. Pick a provider with the `TTS_PROVIDER` environment variable:
+
+| `TTS_PROVIDER` | Provider | Required keys |
+| -------------- | -------- | ------------- |
+| `elevenlabs` (default) | [ElevenLabs](https://beta.elevenlabs.io/sign-up) | `ELEVEN_API_KEY`, `ELEVEN_VOICE_ID` |
+| `60db` | [60db](https://60db.ai) | `SIXTYDB_API_KEY`, `SIXTYDB_VOICE_ID` |
+
+- **ElevenLabs** — sign up [here](https://beta.elevenlabs.io/sign-up) for a free account.
+- **60db** — sign up at [60db.ai](https://60db.ai) for an API key. Your `SIXTYDB_VOICE_ID` is a UUID retrieved from the [`/myvoices`](https://docs.60db.ai/api-reference/voices/get-my-voices) endpoint (leave blank to use 60db's default voice).
+
 ### Config
-- First, add your OpenAI and ElevenLabs API keys as well as the name of the TikTok account that's livestreaming in the `.env.example` file
+- First, in the `.env.example` file: set `TTS_PROVIDER`, add your OpenAI key, add the keys for your chosen TTS provider, and set the name of the TikTok account that's livestreaming.
 
 
 - Next, rename the `.env.example` file to `.env`
@@ -60,14 +68,38 @@ TiktokChatGPT
 │   └── example.mp3
 ├── logs         # Log file store
 │   └── access.log
-├── app.js       # Tiktok livestream responder
-├── gpt.js       # OpenAI prompt and response function
-├── voice.js     # ElevenLabs vocal response function
-├── logger.js    # Logging function
-├── .env         # Credentials and environment variables
+├── app.js              # Tiktok livestream responder
+├── gpt.js              # OpenAI prompt and response function
+├── voice.js            # TTS dispatcher (selects provider via TTS_PROVIDER)
+├── voiceElevenlabs.js  # ElevenLabs vocal response provider
+├── voice60db.js        # 60db vocal response provider
+├── audioPath.js        # Shared audio file-path builder
+├── logger.js           # Logging function
+├── .env                # Credentials and environment variables
 ├── package.json
 ├── README.md
 ```
+
+### TTS Provider Architecture
+Every provider module exposes the same interface — `vocaliser(text, respondingTo)` returns the path to a saved audio file — so the rest of the app is provider-agnostic.
+
+```
+app.js  ──text──►  voice.js (dispatcher)  ──►  voiceElevenlabs.js ──┐
+                        │ TTS_PROVIDER                              ├──►  audio/*.mp3  ──►  sound-play
+                        └──────────────────►  voice60db.js ────────┘
+```
+
+Switch providers at any time by changing `TTS_PROVIDER` in `.env` (`elevenlabs` or `60db`) — no code changes required.
+
+#### Optional 60db voice tuning
+When `TTS_PROVIDER=60db`, these optional `.env` variables fine-tune the voice (unset = 60db defaults):
+
+| Variable | Range | Purpose |
+| -------- | ----- | ------- |
+| `SIXTYDB_OUTPUT_FORMAT` | `mp3`, `wav`, `ogg`, `flac` | Output audio format (default `mp3`) |
+| `SIXTYDB_SPEED` | `0.5`–`2.0` | Speech rate |
+| `SIXTYDB_STABILITY` | `0`–`100` | Lower = more expressive |
+| `SIXTYDB_SIMILARITY` | `0`–`100` | Voice matching strength |
 
 ## Contribution
 Contributions are welcome. Checkout the [CONTRIBUTING.md](https://github.com/FelixWaweru/TiktokChatGPT/tree/main/docs/CONTRIBUTING.md) to learn more.

--- a/audioPath.js
+++ b/audioPath.js
@@ -1,0 +1,12 @@
+// Builds the per-response audio file path shared by every TTS provider,
+// e.g. audio/<user>--2026-06-18.mp3
+// Date is shifted +3h to localise to UTC+3 (matches the convention in logger.js).
+function audioPath(respondingTo, ext = 'mp3') {
+  const date = new Date(new Date().getTime() + (3 * 60 * 60 * 1000))
+    .toISOString()
+    .slice(0, 10);
+
+  return `audio/${respondingTo}--${date}.${ext}`;
+}
+
+module.exports = audioPath;

--- a/voice.js
+++ b/voice.js
@@ -1,20 +1,26 @@
-const voice = require('elevenlabs-node');
 require('dotenv').config();
-const apiKey = process.env.ELEVEN_API_KEY;
-const voiceID = process.env.ELEVEN_VOICE_ID;
 
-async function vocaliser(text, respondingTo) {
-    const filename = `audio/${respondingTo}--${new Date(new Date().getTime() + (3 * 60 * 60 * 1000)).toISOString().slice(0,10)}.mp3`;
+// Dispatcher: selects the active TTS provider via the TTS_PROVIDER env var.
+// Every provider module exports the same vocaliser(text, respondingTo) -> filePath
+// interface, so app.js stays provider-agnostic.
+//   elevenlabs (default) -> voiceElevenlabs.js
+//   60db                 -> voice60db.js
+const provider = (process.env.TTS_PROVIDER || 'elevenlabs').toLowerCase();
 
-    try {
-      await voice.textToSpeech(apiKey, voiceID, filename, text).then(res => {
-            console.log(`Success, Audio saved as: ${filename}`);
-        });
+const providers = {
+    elevenlabs: './voiceElevenlabs.js',
+    '60db': './voice60db.js',
+    sixtydb: './voice60db.js',
+};
 
-        return filename;
-      } catch (error) {
-        console.error(error);
-      }
+const modulePath = providers[provider];
+
+if (!modulePath) {
+    throw new Error(
+        `Unknown TTS_PROVIDER "${provider}". Use one of: ${Object.keys(providers).join(', ')}`
+    );
 }
 
-module.exports = vocaliser;
+console.log(`TTS provider: ${provider}`);
+
+module.exports = require(modulePath);

--- a/voice60db.js
+++ b/voice60db.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const axios = require('axios');
+const audioPath = require('./audioPath.js');
+require('dotenv').config();
+
+const apiKey = process.env.SIXTYDB_API_KEY;
+const voiceID = process.env.SIXTYDB_VOICE_ID;
+const outputFormat = process.env.SIXTYDB_OUTPUT_FORMAT || 'mp3';
+
+const ENDPOINT = 'https://api.60db.ai/tts-synthesize';
+
+// Converts text to speech with 60db, saving a complete audio file to disk.
+// Mirrors the ElevenLabs vocaliser interface: returns the saved file path
+// (relative to the project root) so app.js can play it unchanged.
+async function vocaliser(text, respondingTo) {
+    const filename = audioPath(respondingTo, outputFormat);
+
+    // 60db caps a single request at 5000 characters.
+    const body = {
+        text: text.slice(0, 5000),
+        voice_id: voiceID,
+        output_format: outputFormat,
+    };
+
+    // Optional voice tuning, only sent when configured (otherwise 60db defaults apply).
+    if (process.env.SIXTYDB_SPEED) body.speed = Number(process.env.SIXTYDB_SPEED);
+    if (process.env.SIXTYDB_STABILITY) body.stability = Number(process.env.SIXTYDB_STABILITY);
+    if (process.env.SIXTYDB_SIMILARITY) body.similarity = Number(process.env.SIXTYDB_SIMILARITY);
+
+    try {
+        const { data } = await axios.post(ENDPOINT, body, {
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!data || !data.success || !data.audio_base64) {
+            const reason = data && data.message ? data.message : 'no audio returned';
+            throw new Error(`60db TTS failed: ${reason}`);
+        }
+
+        // 60db returns base64-encoded audio rather than raw bytes, so decode before saving.
+        fs.writeFileSync(filename, Buffer.from(data.audio_base64, 'base64'));
+        console.log(`Success, Audio saved as: ${filename}`);
+
+        return filename;
+    } catch (error) {
+        console.error(error.response ? error.response.data : error.message);
+    }
+}
+
+module.exports = vocaliser;

--- a/voiceElevenlabs.js
+++ b/voiceElevenlabs.js
@@ -1,0 +1,24 @@
+const voice = require('elevenlabs-node');
+const audioPath = require('./audioPath.js');
+require('dotenv').config();
+
+const apiKey = process.env.ELEVEN_API_KEY;
+const voiceID = process.env.ELEVEN_VOICE_ID;
+
+// Converts text to speech with ElevenLabs, saving a complete mp3 to disk.
+// Returns the saved file path (relative to the project root) for playback.
+async function vocaliser(text, respondingTo) {
+    const filename = audioPath(respondingTo, 'mp3');
+
+    try {
+        await voice.textToSpeech(apiKey, voiceID, filename, text).then(res => {
+            console.log(`Success, Audio saved as: ${filename}`);
+        });
+
+        return filename;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+module.exports = vocaliser;


### PR DESCRIPTION
What we added
  
  - voice60db.js — new 60db text-to-speech provider (POST /tts-synthesize → decodes base64 audio → saves file).
  - voiceElevenlabs.js — the original ElevenLabs logic moved into its own module.
  - voice.js — now a dispatcher that picks the provider from TTS_PROVIDER.
  - audioPath.js — shared helper so both providers name audio files the same way.
  - .env.example + README.md — updated with the new variables and docs.

  Both providers share one interface, so app.js is unchanged. No new dependencies (axios was already there).

  How to use it

  In .env:
  TTS_PROVIDER=60db          # or "elevenlabs" (default)
  SIXTYDB_API_KEY=sk_live_...
  SIXTYDB_VOICE_ID=<uuid from 60db /myvoices>   # blank = default voice
  Then run npm install && npm start. Switch back anytime with TTS_PROVIDER=elevenlabs — no code changes.

  Optional 60db tuning: SIXTYDB_OUTPUT_FORMAT (mp3/wav/ogg/flac), SIXTYDB_SPEED (0.5–2.0), SIXTYDB_STABILITY (0–100),
  SIXTYDB_SIMILARITY (0–100).